### PR TITLE
Fixed Crash in create_driver_utils.py

### DIFF
--- a/botasaurus/create_driver_utils.py
+++ b/botasaurus/create_driver_utils.py
@@ -3,6 +3,7 @@ import os
 from sys import argv
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.common.exceptions import SessionNotCreatedException
 from shutil import rmtree
 from .get_chrome_version import get_driver_path
 from selenium.common.exceptions import SessionNotCreatedException


### PR DESCRIPTION
Error in create_driver_utils.py, line 226, in create_selenium_driver:
`NameError: name 'SessionNotCreatedException' is not defined`

Fix was to just import the correct type.